### PR TITLE
49. 字母异位词分组(中等)

### DIFF
--- a/src/com/yang/problem49/Solution.java
+++ b/src/com/yang/problem49/Solution.java
@@ -1,0 +1,56 @@
+package com.yang.problem49;
+
+import java.util.*;
+
+/**
+ * 49. 字母异位词分组(中等)
+ * 给定一个字符串数组，将字母异位词组合在一起。字母异位词指字母相同，但排列不同的字符串。
+ *
+ * 示例:
+ * 输入: ["eat", "tea", "tan", "ate", "nat", "bat"]
+ * 输出:
+ * [
+ * ["ate","eat","tea"],
+ * ["nat","tan"],
+ * ["bat"]
+ * ]
+ *
+ * 说明：
+ * 所有输入均为小写字母。
+ * 不考虑答案输出的顺序。
+ *
+ * @author Daze
+ * @date 2021-01-18
+ */
+public class Solution {
+    public static List<List<String>> groupAnagrams(String[] strs) {
+        Map<String, List<String>> map = new HashMap<>();
+        for (String str : strs) {
+            int[] counts = new int[26];
+            int length = str.length();
+            for (int i = 0; i < length; i++) {
+                counts[str.charAt(i) - 'a']++;
+            }
+            // 将每个出现次数大于 0 的字母和出现次数按顺序拼接成字符串，作为哈希表的键
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 26; i++) {
+                if (counts[i] != 0) {
+                    sb.append((char) ('a' + i));
+                    sb.append(counts[i]);
+                }
+            }
+            String key = sb.toString();
+            List<String> list = map.getOrDefault(key, new ArrayList<>());
+            list.add(str);
+            map.put(key, list);
+        }
+        return new ArrayList<>(map.values());
+    }
+
+    public static void main(String[] args) {
+        String[] strs = {"eat", "tea", "tan", "ate", "nat", "bat"};
+        // ans = [[bat], [tan, nat], [eat, tea, ate]]
+        List<List<String>> ans = groupAnagrams(strs);
+        System.out.println(Arrays.toString(ans.toArray()));
+    }
+}


### PR DESCRIPTION
### 计数法：
由于互为字母异位词的两个字符串包含的字母相同，因此两个字符串中的相同字母出现的次数一定是相同的，故可以将每个字母出现的次数使用字符串表示，作为哈希表的键。

由于字符串只包含小写字母，因此对于每个字符串，可以使用长度为 2626 的数组记录每个字母出现的次数。需要注意的是，在使用数组作为哈希表的键时，不同语言的支持程度不同，因此不同语言的实现方式也不同。

转自：[力扣（LeetCode）](https://leetcode-cn.com/problems/group-anagrams/solution/zi-mu-yi-wei-ci-fen-zu-by-leetcode-solut-gyoc/)